### PR TITLE
Add dependencies to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(name='astroplant-client',
       author='AstroPlant',
       author_email='thomas@kepow.org',
       url='https://astroplant.io',
-      packages=['astroplant_client',],
+      packages=['astroplant_client'],
+	  install_requires=['requests', 'pyjwt', 'websocket-client']
      )
 


### PR DESCRIPTION
When installing astroplant-client from astroplant-kit, the required dependencies are not installed, resulting in missing packages. This commit solves this issue by forcing setuptools to install these missing packages when installing astroplant-client.